### PR TITLE
ci: remove go-version reference in stages

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -59,10 +59,12 @@ pipeline {
           }
         }
         stages {
-          stage('build'){
+          stage('Build'){
             steps {
               withGithubNotify(context: "Build-${PLATFORM}") {
-                deleteDir()
+                whenTrue(isUnix()) {
+                  deleteDir()
+                }
                 unstash 'source'
                 dir("${BASE_DIR}"){
                   withGoEnv(){
@@ -75,8 +77,6 @@ pipeline {
           stage('Test') {
             steps {
               withGithubNotify(context: "Test-${PLATFORM}") {
-                deleteDir()
-                unstash 'source'
                 dir("${BASE_DIR}"){
                   withGoEnv(){
                     goTestJUnit(options: '-v ./...', output: 'junit-report.xml')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
         stages {
           stage('build'){
             steps {
-              withGithubNotify(context: "Build-${GO_VERSION}-${PLATFORM}") {
+              withGithubNotify(context: "Build-${PLATFORM}") {
                 deleteDir()
                 unstash 'source'
                 dir("${BASE_DIR}"){
@@ -74,7 +74,7 @@ pipeline {
           }
           stage('Test') {
             steps {
-              withGithubNotify(context: "Test-${GO_VERSION}-${PLATFORM}") {
+              withGithubNotify(context: "Test-${PLATFORM}") {
                 deleteDir()
                 unstash 'source'
                 dir("${BASE_DIR}"){


### PR DESCRIPTION
`GO_VERSION` is not anymore part of the matrix, therefore its references should not be there.

Regression while manually changing the pipeline definition in https://github.com/elastic/elastic-agent-shipper/pull/2