### PR TITLE
Mark all code as owned by the data plane team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# GitHub CODEOWNERS definition
+# See: https://help.github.com/articles/about-codeowners/
+* @elastic/elastic-agent-data-plane


### PR DESCRIPTION
Add a CODEOWNERS file. I'm going to configure the repository to choose two random reviewers from our team like the other repositories do.