### PR TITLE
Add package and API skeleton for internal queue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/magefile/mage v1.13.0
 	github.com/stretchr/testify v1.7.0
 	go.elastic.co/go-licence-detector v0.5.0
+	golang.org/x/net v0.0.0-20220412020605-290c469a71a5
 )
 
 require (
@@ -65,7 +66,6 @@ require (
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
-	golang.org/x/net v0.0.0-20220412020605-290c469a71a5 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	golang.org/x/text v0.3.7 // indirect
@@ -81,3 +81,5 @@ replace (
 	github.com/dop251/goja => github.com/andrewkroh/goja v0.0.0-20190128172624-dd2ac4456e20
 	github.com/dop251/goja_nodejs => github.com/dop251/goja_nodejs v0.0.0-20171011081505-adff31b136e6
 )
+
+replace github.com/elastic/beats => /Users/fae/go/src/github.com/elastic/beats

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/magefile/mage v1.13.0
 	github.com/stretchr/testify v1.7.0
 	go.elastic.co/go-licence-detector v0.5.0
-	golang.org/x/net v0.0.0-20220412020605-290c469a71a5
 )
 
 require (
@@ -66,6 +65,7 @@ require (
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
+	golang.org/x/net v0.0.0-20220412020605-290c469a71a5 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	golang.org/x/text v0.3.7 // indirect
@@ -81,5 +81,3 @@ replace (
 	github.com/dop251/goja => github.com/andrewkroh/goja v0.0.0-20190128172624-dd2ac4456e20
 	github.com/dop251/goja_nodejs => github.com/dop251/goja_nodejs v0.0.0-20171011081505-adff31b136e6
 )
-
-replace github.com/elastic/beats => /Users/fae/go/src/github.com/elastic/beats

--- a/monitoring/queuemon_test.go
+++ b/monitoring/queuemon_test.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/opt"
-	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 	expvarReport "github.com/elastic/elastic-agent-shipper/monitoring/reporter/expvar"
+	"github.com/elastic/elastic-agent-shipper/queue"
 )
 
 func init() {
@@ -54,26 +54,6 @@ func NewTestQueue(limit uint64) *TestMetricsQueue {
 		},
 		limit: limit,
 	}
-}
-
-// BufferConfig doesn't do anything
-func (tq TestMetricsQueue) BufferConfig() queue.BufferConfig {
-	return queue.BufferConfig{}
-}
-
-// Producer doesn't do anything
-func (tq TestMetricsQueue) Producer(_ queue.ProducerConfig) queue.Producer {
-	return nil
-}
-
-// Consumer doesn't do anything
-func (tq TestMetricsQueue) Consumer() queue.Consumer {
-	return nil
-}
-
-// Close Doesn't do anything
-func (tq TestMetricsQueue) Close() error {
-	return nil
 }
 
 // Metrics spoofs the metrics output

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -32,7 +32,7 @@ func New() (*Queue, error) {
 	return &Queue{}, nil
 }
 
-func (queue *Queue) PublishOrSomething(event *api.Event) {
+func (queue *Queue) Publish(event *api.Event) {
 
 }
 

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -1,0 +1,33 @@
+package queue
+
+import (
+	beatsqueue "github.com/elastic/beats/v7/libbeat/publisher/queue"
+
+	"github.com/elastic/elastic-agent-shipper/api"
+)
+
+// Queue is a shipper-specific wrapper around the bare libbeat queue.
+// It accepts api.Event instead of bare interface pointers like the
+// libbeat queue, and it sets opinionated defaults for the queue
+// semantics. The intention is to keep the shipper from becoming too
+// entangled with the legacy queue api, and to gradually expose more
+// features as the libbeat queue evolves and we decide what we want
+// to support in the shipper.
+type Queue struct {
+	eventQueue beatsqueue.Queue
+
+	producer beatsqueue.Producer
+}
+
+type Metrics beatsqueue.Metrics
+
+// metricsSource is a wrapper around the libbeat queue interface, exposing only
+// the callback to query the current metrics. It is used to pass queue metrics
+// to the monitoring package.
+type MetricsSource interface {
+	Metrics() (Metrics, error)
+}
+
+func (queue *Queue) PublishOrSomething(event *api.Event) {
+
+}

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -1,6 +1,8 @@
 package queue
 
 import (
+	"fmt"
+
 	beatsqueue "github.com/elastic/beats/v7/libbeat/publisher/queue"
 
 	"github.com/elastic/elastic-agent-shipper/api"
@@ -32,8 +34,8 @@ func New() (*Queue, error) {
 	return &Queue{}, nil
 }
 
-func (queue *Queue) Publish(event *api.Event) {
-
+func (queue *Queue) Publish(event *api.Event) error {
+	return fmt.Errorf("couldn't publish: Queue.Publish is not implemented")
 }
 
 func (queue *Queue) Metrics() (Metrics, error) {

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -16,7 +16,7 @@ import (
 type Queue struct {
 	eventQueue beatsqueue.Queue
 
-	producer beatsqueue.Producer
+	//producer beatsqueue.Producer
 }
 
 type Metrics beatsqueue.Metrics
@@ -28,6 +28,20 @@ type MetricsSource interface {
 	Metrics() (Metrics, error)
 }
 
+func New() (*Queue, error) {
+	return &Queue{}, nil
+}
+
 func (queue *Queue) PublishOrSomething(event *api.Event) {
+
+}
+
+func (queue *Queue) Metrics() (Metrics, error) {
+	metrics, err := queue.eventQueue.Metrics()
+	// We need to do the explicit cast, otherwise this isn't recognized as the same type
+	return Metrics(metrics), err
+}
+
+func (queue *Queue) Close() {
 
 }

--- a/server/run.go
+++ b/server/run.go
@@ -18,6 +18,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-shipper/config"
 	"github.com/elastic/elastic-agent-shipper/monitoring"
+	"github.com/elastic/elastic-agent-shipper/queue"
 
 	pb "github.com/elastic/elastic-agent-shipper/api"
 )
@@ -62,6 +63,14 @@ func handleShutdown(stopFunc func(), log *logp.Logger) {
 // Run starts the gRPC server
 func Run(cfg config.ShipperConfig) error {
 	log := logp.L()
+
+	// When there is queue-specific configuration in ShipperConfig, it should
+	// be passed in here.
+	queue, err := queue.New()
+	if err != nil {
+		return fmt.Errorf("couldn't create queue: %w", err)
+	}
+
 	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", cfg.Port))
 	if err != nil {
 		return fmt.Errorf("failed to listen: %w", err)
@@ -69,7 +78,7 @@ func Run(cfg config.ShipperConfig) error {
 
 	// Beats won't call the "New*" functions of a queue directly, but instead fetch a queueFactory from the global registers.
 	//However, that requires the publisher/pipeline code as well, and I'm not sure we want that.
-	monHandler, err := loadMonitoring(cfg)
+	monHandler, err := loadMonitoring(cfg, queue)
 	if err != nil {
 		return fmt.Errorf("error loading outputs: %w", err)
 	}
@@ -91,6 +100,7 @@ func Run(cfg config.ShipperConfig) error {
 	shutdownFunc := func() {
 		grpcServer.GracefulStop()
 		monHandler.End()
+		queue.Close()
 	}
 	handleShutdown(shutdownFunc, log)
 	log.Debugf("gRPC server is listening on port %d", cfg.Port)
@@ -99,13 +109,9 @@ func Run(cfg config.ShipperConfig) error {
 }
 
 // Initialize metrics and outputs
-func loadMonitoring(cfg config.ShipperConfig) (*monitoring.QueueMonitor, error) {
-	//If we had an actual queue hooked up, that would go here
-	//queue := NewTestQueue()
-
+func loadMonitoring(cfg config.ShipperConfig, queue *queue.Queue) (*monitoring.QueueMonitor, error) {
 	//startup monitor
-	//remove the nil in the second argument here when we have an actual queue.
-	mon, err := monitoring.NewFromConfig(cfg.Monitor, nil)
+	mon, err := monitoring.NewFromConfig(cfg.Monitor, queue)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing output monitor: %w", err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -28,7 +28,15 @@ func (serv shipperServer) PublishEvents(_ context.Context, req *pb.PublishReques
 	results := []*pb.EventResult{}
 	for _, evt := range req.Events {
 		serv.logger.Infof("Got event %s: %#v", evt.EventId, evt.Fields.AsMap())
-		serv.queue.Publish(evt)
+		err := serv.queue.Publish(evt)
+		if err != nil {
+			// If we couldn't accept any events, return the error directly. Otherwise,
+			// just return success on however many events we were able to handle.
+			if len(results) == 0 {
+				return nil, err
+			}
+			break
+		}
 		res := pb.EventResult{EventId: evt.EventId, Timestamp: pbts.Now()}
 		results = append(results, &res)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -12,10 +12,14 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/logp"
 	pb "github.com/elastic/elastic-agent-shipper/api"
+	"github.com/elastic/elastic-agent-shipper/queue"
 )
 
 type shipperServer struct {
 	logger *logp.Logger
+
+	queue *queue.Queue
+
 	pb.UnimplementedProducerServer
 }
 
@@ -24,6 +28,7 @@ func (serv shipperServer) PublishEvents(_ context.Context, req *pb.PublishReques
 	results := []*pb.EventResult{}
 	for _, evt := range req.Events {
 		serv.logger.Infof("Got event %s: %#v", evt.EventId, evt.Fields.AsMap())
+		serv.queue.PublishOrSomething(evt)
 		res := pb.EventResult{EventId: evt.EventId, Timestamp: pbts.Now()}
 		results = append(results, &res)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -28,7 +28,7 @@ func (serv shipperServer) PublishEvents(_ context.Context, req *pb.PublishReques
 	results := []*pb.EventResult{}
 	for _, evt := range req.Events {
 		serv.logger.Infof("Got event %s: %#v", evt.EventId, evt.Fields.AsMap())
-		serv.queue.PublishOrSomething(evt)
+		serv.queue.Publish(evt)
 		res := pb.EventResult{EventId: evt.EventId, Timestamp: pbts.Now()}
 		results = append(results, &res)
 	}


### PR DESCRIPTION
This is the first pass of integrating the libbeat queue into the shipper server. It creates the package namespace and structures and passes through the initialization / shutdown process, but doesn't yet use a real queue internally (that is waiting on the libbeat-side api changes to be merged in https://github.com/elastic/beats/pull/31699). But this creates a skeleton and moves things to the right places so we can keep building around it without version skew from the draft PRs.