### PR TITLE
Add placeholders for queue entry id calls

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -58,11 +58,11 @@ func New() (*Queue, error) {
 	return &Queue{eventQueue: eventQueue, producer: producer}, nil
 }
 
-func (queue *Queue) Publish(event *messages.Event) (EventId, error) {
+func (queue *Queue) Publish(event *messages.Event) (EntryId, error) {
 	if !queue.producer.Publish(event) {
-		return EventId(0), ErrQueueIsFull
+		return EntryId(0), ErrQueueIsFull
 	}
-	return EventId(0), nil
+	return EntryId(0), nil
 }
 
 func (queue *Queue) Metrics() (Metrics, error) {

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -79,11 +79,11 @@ func (queue *Queue) Close() {
 	queue.eventQueue.Close()
 }
 
-func (queue *Queue) AcceptedEntryID() EntryID {
+func (queue *Queue) AcceptedIndex() EntryID {
 	return EntryID(0)
 }
 
-func (queue *Queue) PersistedEntryID() EntryID {
+func (queue *Queue) PersistedIndex() EntryID {
 	// This function needs to be implemented differently depending on the queue
 	// type. For the memory queue, it should return the most recent sequential
 	// entry id that has been published and acknowledged by the outputs.

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -30,10 +30,10 @@ type Queue struct {
 
 type Metrics beatsqueue.Metrics
 
-// EntryId is a unique ascending id assigned to each entry that goes in the
+// EntryID is a unique ascending id assigned to each entry that goes in the
 // queue, to handle acknowledgments within the shipper and report progress
 // to the client.
-type EntryId uint64
+type EntryID uint64
 
 // metricsSource is a wrapper around the libbeat queue interface, exposing only
 // the callback to query the current metrics. It is used to pass queue metrics
@@ -58,11 +58,11 @@ func New() (*Queue, error) {
 	return &Queue{eventQueue: eventQueue, producer: producer}, nil
 }
 
-func (queue *Queue) Publish(event *messages.Event) (EntryId, error) {
+func (queue *Queue) Publish(event *messages.Event) (EntryID, error) {
 	if !queue.producer.Publish(event) {
-		return EntryId(0), ErrQueueIsFull
+		return EntryID(0), ErrQueueIsFull
 	}
-	return EntryId(0), nil
+	return EntryID(0), nil
 }
 
 func (queue *Queue) Metrics() (Metrics, error) {
@@ -79,15 +79,15 @@ func (queue *Queue) Close() {
 	queue.eventQueue.Close()
 }
 
-func (queue *Queue) AcceptedEntryId() EntryId {
-	return EntryId(0)
+func (queue *Queue) AcceptedEntryID() EntryID {
+	return EntryID(0)
 }
 
-func (queue *Queue) PersistedEntryId() EntryId {
+func (queue *Queue) PersistedEntryID() EntryID {
 	// This function needs to be implemented differently depending on the queue
 	// type. For the memory queue, it should return the most recent sequential
 	// entry id that has been published and acknowledged by the outputs.
 	// For the disk queue, it should return the most recent sequential entry id
 	// that has been written to disk.
-	return EntryId(0)
+	return EntryID(0)
 }

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -20,7 +20,7 @@ func TestSimpleBatch(t *testing.T) {
 	eventCount := 100
 	events := make([]messages.Event, eventCount)
 	for i := 0; i < eventCount; i++ {
-		err = queue.Publish(&events[i])
+		_, err = queue.Publish(&events[i])
 		assert.NoError(t, err, "couldn't publish to queue")
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -29,7 +29,7 @@ func (serv shipperServer) PublishEvents(_ context.Context, req *messages.Publish
 	results := []*messages.EventResult{}
 	for _, evt := range req.Events {
 		serv.logger.Infof("Got event %s: %#v", evt.EventId, evt.Fields.Data)
-		err := serv.queue.Publish(evt)
+		_, err := serv.queue.Publish(evt)
 		if err != nil {
 			// If we couldn't accept any events, return the error directly. Otherwise,
 			// just return success on however many events we were able to handle.


### PR DESCRIPTION
This adds functions on the queue interface to report the accepted and persisted event ids needed by https://github.com/elastic/elastic-agent-shipper/pull/76/. Its implementation depends on pending work in the libbeat queues, but this gives a call site for the server to use in the meantime.