### PR TITLE
Add `StrictMode` with event validation

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	_ "github.com/elastic/elastic-agent-libs/logp/configure"
-	"github.com/elastic/elastic-agent-shipper/server"
+	"github.com/elastic/elastic-agent-shipper/controller"
 )
 
 // NewCommand returns a new command structure
@@ -41,7 +41,7 @@ func runCmd() *cobra.Command {
 		Use:   "run",
 		Short: "Start the elastic-agent-shipper.",
 		Run: func(_ *cobra.Command, _ []string) {
-			if err := server.LoadAndRun(); err != nil {
+			if err := controller.LoadAndRun(); err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n\n", err)
 				os.Exit(1)
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-shipper/monitoring"
 	"github.com/elastic/elastic-agent-shipper/queue"
+	"github.com/elastic/elastic-agent-shipper/server"
 	"github.com/elastic/go-ucfg/json"
 )
 
@@ -43,6 +44,7 @@ type ShipperConfig struct {
 	Port    int               `config:"port"`       //Port to listen on
 	Monitor monitoring.Config `config:"monitoring"` //Queue monitoring settings
 	Queue   queue.Config      `config:"queue"`      //Queue settings
+	Server  server.Config     `config:"server"`     //gRPC Server settings
 }
 
 // ReadConfig returns the populated config from the specified path
@@ -64,6 +66,7 @@ func ReadConfig() (ShipperConfig, error) {
 		Log:     logp.DefaultConfig(logp.SystemdEnvironment),
 		Monitor: monitoring.DefaultConfig(),
 		Queue:   queue.DefaultConfig(),
+		Server:  server.DefaultConfig(),
 	}
 	err = raw.Unpack(&config)
 	if err != nil {
@@ -84,6 +87,7 @@ func ReadConfigFromJSON(raw string) (ShipperConfig, error) {
 		Log:     logp.DefaultConfig(logp.SystemdEnvironment),
 		Monitor: monitoring.DefaultConfig(),
 		Queue:   queue.DefaultConfig(),
+		Server:  server.DefaultConfig(),
 	}
 	err = rawCfg.Unpack(&shipperConfig)
 	if err != nil {

--- a/controller/controller_client.go
+++ b/controller/controller_client.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package server
+package controller
 
 import (
 	"context"

--- a/controller/controller_client_test.go
+++ b/controller/controller_client_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package server
+package controller
 
 import (
 	"context"

--- a/controller/run.go
+++ b/controller/run.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package server
+package controller
 
 import (
 	"context"
@@ -22,6 +22,7 @@ import (
 	"github.com/elastic/elastic-agent-shipper/monitoring"
 	"github.com/elastic/elastic-agent-shipper/output"
 	"github.com/elastic/elastic-agent-shipper/queue"
+	"github.com/elastic/elastic-agent-shipper/server"
 
 	pb "github.com/elastic/elastic-agent-shipper-client/pkg/proto"
 )
@@ -104,7 +105,7 @@ func (c *clientHandler) Run(cfg config.ShipperConfig, unit *client.Unit) error {
 		opts = []grpc.ServerOption{grpc.Creds(creds)}
 	}
 	grpcServer := grpc.NewServer(opts...)
-	shipperServer, err := NewShipperServer(queue)
+	shipperServer, err := server.NewShipperServer(cfg.Server, queue)
 	if err != nil {
 		return fmt.Errorf("failed to initialise the server: %w", err)
 	}

--- a/server/config.go
+++ b/server/config.go
@@ -1,0 +1,20 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package server
+
+type Config struct {
+	// StrictMode means that every incoming event will be validated against the
+	// list of required fields. This introduces some additional overhead but can
+	// be really handy for client developers on the debugging stage.
+	// Normally, it should be disabled during production use and enabled for testing.
+	StrictMode bool `config:"strict_mode"`
+}
+
+// DefaultConfig returns default configuration for the gRPC server
+func DefaultConfig() Config {
+	return Config{
+		StrictMode: false,
+	}
+}

--- a/server/config.go
+++ b/server/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	// list of required fields. This introduces some additional overhead but can
 	// be really handy for client developers on the debugging stage.
 	// Normally, it should be disabled during production use and enabled for testing.
+	// In production it is preferable to send events to the output if at all possible.
 	StrictMode bool `config:"strict_mode"`
 }
 


### PR DESCRIPTION
In `StrictMode` required fields are:

* Timestamp
* Datastream.Namespace
* Datastream.Dataset
* Datastream.Type
* Source.InputId

Closes https://github.com/elastic/elastic-agent-shipper/issues/79