### PR TITLE
Added support for 'mage package:all'

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -45,6 +45,7 @@ const (
 // nolint: deadcode // it's used by `mage`.
 var Aliases = map[string]interface{}{
 	"build":           Build.Binary,
+	"package":         Package.Artifacts,
 	"unitTest":        Test.Unit,
 	"integrationTest": Test.Integration,
 }
@@ -223,8 +224,17 @@ func Notice() error {
 
 // PACKAGE
 
+// Package contains targets related to producting project archives
+type Package mg.Namespace
+
+// All builds binaries for the all os/arch and produces resulting archives.
+func (Package) All() {
+	os.Setenv("PLATFORMS", "all")
+	mg.Deps(Package.Artifacts)
+}
+
 // Package runs all the checks including licence, notice, gomod, git changes, followed by binary build.
-func Package() {
+func (Package) Artifacts() {
 	// these are not allowed in parallel
 	mg.SerialDeps(
 		Build.Binary,


### PR DESCRIPTION
## What does this PR do?

Adds a new sub-command for `package` command which builds All PLATFORMS.
No need to set ENV vars.

## Why is it important?

Having `package:all` makes CI script nicer

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md` or `CHANGELOG-developer.md`.
