### PR TITLE
ci: honour the SNAPSHOT variable to fix the build errors in the CI

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -48,6 +48,9 @@ pipeline {
       }
     }
     stage('Test') {
+      environment {
+        SNAPSHOT = 'true'
+      }
       failFast false
       matrix {
         agent {label "${PLATFORM}"}


### PR DESCRIPTION
## What does this PR do?

`mage build ` fails in the CI with the below error:

```
[2022-09-30T07:32:31.268Z] >> build: Building binary for linux/amd64

[2022-09-30T07:32:31.268Z] exec: goreleaser "build" "--rm-dist" "--skip-validate" "--id" "linux" "--single-target"
...
[2022-09-30T07:32:31.369Z]    ⨯ build failed after 0.04s error=git doesn't contain any tags. Either add a tag or use --snapshot
[2022-09-30T07:32:31.369Z] Error: Build failed on linux/amd64: running "goreleaser build --rm-dist --skip-validate --id linux --single-target" failed with exit code 1
script returned exit code 1
```

## Why is it important?

Fixes the CI