### PR TITLE
Add dependencies generation

### DIFF
--- a/dev-tools/common.bash
+++ b/dev-tools/common.bash
@@ -1,0 +1,112 @@
+#
+# File: common.bash
+#
+# Common bash routines.
+#
+
+# Script directory:
+_sdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# debug "msg"
+# Write a debug message to stderr.
+debug()
+{
+  if [ "$VERBOSE" == "true" ]; then
+    echo "DEBUG: $1" >&2
+  fi
+}
+
+# err "msg"
+# Write and error message to stderr.
+err()
+{
+  echo "ERROR: $1" >&2
+}
+
+# get_go_version
+# Read the project's Go version and return it in the GO_VERSION variable.
+# On failure it will exit.
+get_go_version() {
+  GO_VERSION=$(cat "${_sdir}/../.go-version")
+  if [ -z "$GO_VERSION" ]; then
+    err "Failed to detect the project's Go version"
+    exit 1
+  fi
+}
+
+# install_gvm
+# Install gvm to /usr/local/bin.
+# To read more about installing gvm in other platforms: https://github.com/andrewkroh/gvm#installation
+install_gvm() {
+  # Install gvm
+  if [ ! -f "/usr/local/bin/gvm" ]; then
+    curl -sL -o ~/bin/gvm https://github.com/andrewkroh/gvm/releases/download/v0.3.0/gvm-linux-amd64
+    chmod +x /usr/local/bin/gvm
+  fi
+
+  GVM="/usr/local/bin/gvm"
+  debug "Gvm version $(${GVM} --version)"
+}
+
+# setup_go_root "version"
+# This configures the Go version being used. It sets GOROOT and adds
+# GOROOT/bin to the PATH. It uses gimme to download the Go version if
+# it does not already exist in the ~/.gimme dir.
+setup_go_root() {
+  local version=${1}
+
+  install_gvm
+
+  # Setup GOROOT and add go to the PATH.
+  eval "$(${GVM} ${version})"
+
+  debug "$(go version)"
+}
+
+# setup_go_path "gopath"
+# This sets GOPATH and adds GOPATH/bin to the PATH.
+setup_go_path() {
+  local gopath="${1}"
+  if [ -z "$gopath" ]; then return; fi
+
+  # Setup GOPATH.
+  export GOPATH="${gopath}"
+
+  # Add GOPATH to PATH.
+  export PATH="${GOPATH}/bin:${PATH}"
+
+  debug "GOPATH=${GOPATH}"
+}
+
+jenkins_setup() {
+  : "${HOME:?Need to set HOME to a non-empty value.}"
+  : "${WORKSPACE:?Need to set WORKSPACE to a non-empty value.}"
+
+  if [ -z ${GO_VERSION:-} ]; then
+    get_go_version
+  fi
+
+  # Setup Go.
+  export GOPATH=${WORKSPACE}
+  export PATH=${GOPATH}/bin:${PATH}
+  eval "$(gvm ${GO_VERSION})"
+
+  # Workaround for Python virtualenv path being too long.
+  export TEMP_PYTHON_ENV=$(mktemp -d)
+  export PYTHON_ENV="${TEMP_PYTHON_ENV}/python-env"
+
+  # Write cached magefile binaries to workspace to ensure
+  # each run starts from a clean slate.
+  export MAGEFILE_CACHE="${WORKSPACE}/.magefile"
+}
+
+docker_setup() {
+  OS="$(uname)"
+  case $OS in
+    'Darwin')
+      # Start the docker machine VM (ignore error if it's already running).
+      docker-machine start default || true
+      eval $(docker-machine env default)
+      ;;
+  esac
+}

--- a/dev-tools/dependencies-report
+++ b/dev-tools/dependencies-report
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+set -e
+set -x
+
+SRCPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+outfile=dependencies.csv
+
+while :; do
+	case $1 in
+		--csv)
+			if [ "$2" ]; then
+				outfile=$2
+			else
+				echo "ERROR: --csv needs a non-empty argument"
+				exit 1
+			fi
+			shift
+			;;
+		--csv=?*)
+			outfile=${1#*=}
+			;;
+		--csv=)
+			echo "ERROR: --csv needs a non-empty argument"
+			exit 1
+			;;
+		*)
+			break
+			;;
+	esac
+
+	shift
+done
+
+go mod tidy
+go mod download
+GOPATH=`go env GOPATH`
+env GOBIN=$GOPATH/bin/ go install go.elastic.co/go-licence-detector@v0.4.0
+go list -m -json all $@ | $GOPATH/bin/go-licence-detector \
+		-includeIndirect \
+		-rules "$SRCPATH/templates/notice/rules.json" \
+		-overrides "$SRCPATH/templates/notice/overrides.json" \
+		-noticeTemplate "$SRCPATH/templates/dependencies.csv.tmpl" \
+		-noticeOut "$outfile" \
+		-depsOut ""

--- a/dev-tools/run_with_go_ver
+++ b/dev-tools/run_with_go_ver
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# This sets up Go based on the project's Go version. It will configure
+# GOROOT and add GOROOT/bin to PATH before executing the given command.
+#
+# Example usage: ./run_with_go_ver go version
+#
+set -e
+
+# Script directory:
+SDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "${SDIR}/common.bash"
+
+get_go_version
+setup_go_root ${GO_VERSION}
+bash -c "$*"

--- a/dev-tools/templates/dependencies.csv.tmpl
+++ b/dev-tools/templates/dependencies.csv.tmpl
@@ -1,0 +1,7 @@
+{{- define "depInfo" -}}
+{{- range $i, $dep := . }}
+{{ $dep.Name }},{{ $dep.URL }},{{ $dep.Version | canonicalVersion }},{{ $dep.Version | revision }},{{ $dep.LicenceType }},
+{{- end -}}
+{{- end -}}
+
+name,url,version,revision,license,sourceURL{{ template "depInfo" .Direct }}{{ template "depInfo" .Indirect }}


### PR DESCRIPTION
## What does this PR do?

Similar as in fleet server this PR adds a support for generating dependencies file used during release.

## Why is it important?

Build/release support
Script files are just a copy from another repo

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md` or `CHANGELOG-developer.md`.


Resulting csv file looks like this:
<img width="938" alt="image" src="https://user-images.githubusercontent.com/1522652/197484445-9eb4c6f0-fa29-4a42-b510-c67269b940b9.png">
