### PR TITLE
Fix package naming to include version

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -328,7 +328,7 @@ func (Package) Artifacts() {
 		var archiveFileName string
 		targetDir := fmt.Sprintf("%s-%s", devtools.ProjectName, platform)
 		if isWindows {
-			archiveFileName = fmt.Sprintf("%s-%s.zip", devtools.ProjectName, platform)
+			archiveFileName = fmt.Sprintf("%s-%s-%s.zip", devtools.ProjectName, version, platform)
 			err = prepareZipArchive(
 				archivePath,
 				targetDir,
@@ -340,7 +340,7 @@ func (Package) Artifacts() {
 				},
 			)
 		} else {
-			archiveFileName = fmt.Sprintf("%s-%s.tar.gz", devtools.ProjectName, platform)
+			archiveFileName = fmt.Sprintf("%s-%s-%s.tar.gz", devtools.ProjectName, version, platform)
 			err = prepareTarArchive(
 				archivePath,
 				targetDir,


### PR DESCRIPTION
This PR just changes package name from 
`elastic-agent-shipper-8.5.0-darwin-aarch64.tar.gz` to
`elastic-agent-shipper-darwin-aarch64.tar.gz`

so it includes version properly