### PR TITLE
Add versioning information

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,7 +15,7 @@ builds:
       - -buildmode=pie
     ldflags:
       - '{{ if eq .Env.DEV "false" }}-s -w{{ end }}'
-      - -X main.Version={{ .Env.DEFAULT_VERSION }} -X main.Commit={{.Commit}} -X main.BuildTime={{.Date}}
+      - -X github.com/elastic/elastic-agent-shipper/tools.commit={{.Commit}} -X github.com/elastic/elastic-agent-shipper/tools.buildTime={{.Date}} -X github.com/elastic/elastic-agent-shipper/tools.snapshot={{ .Env.SNAPSHOT }}
     gcflags:
       - '{{ if eq .Env.DEV "true" }}all=-N -l{{ end }}'
     no_unique_dist_dir: true
@@ -30,7 +30,7 @@ builds:
     no_unique_dist_dir: true
     ldflags:
       - '{{ if eq .Env.DEV "false" }}-s -w{{end}}'
-      - -X main.Version={{ .Env.DEFAULT_VERSION }} -X main.Commit={{.Commit}} -X main.BuildTime={{.Date}}
+      - -X github.com/elastic/elastic-agent-shipper/tools.commit={{.Commit}} -X github.com/elastic/elastic-agent-shipper/tools.buildTime={{.Date}} -X github.com/elastic/elastic-agent-shipper/tools.snapshot={{ .Env.SNAPSHOT }}
     gcflags:
       - '{{ if eq .Env.DEV "true" }}all=-N -l{{ end }}'
     overrides:
@@ -58,7 +58,7 @@ builds:
       - -buildmode=pie
     ldflags:
       - '{{ if eq .Env.DEV "false" }}-s -w{{ end }}'
-      - -X main.Version={{ .Env.DEFAULT_VERSION }} -X main.Commit={{.Commit}} -X main.BuildTime={{.Date}}
+      - -X github.com/elastic/elastic-agent-shipper/tools.commit={{.Commit}} -X github.com/elastic/elastic-agent-shipper/tools.buildTime={{.Date}} -X github.com/elastic/elastic-agent-shipper/tools.snapshot={{ .Env.SNAPSHOT }}
     gcflags:
       - '{{ if eq .Env.DEV "true" }}all=-N -l{{ end }}'
 changelog:

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -31,6 +31,9 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("c"))
 
 	run := runCmd()
+
+	cmd.AddCommand(newVersionCommand())
+	cmd.AddCommand(run)
 	cmd.Run = run.Run
 
 	return cmd

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/elastic/elastic-agent-shipper/tools"
 	"github.com/spf13/cobra"
@@ -17,8 +18,8 @@ func newVersionCommand() *cobra.Command {
 		Short: "Version returns version and build information.",
 		Long:  `Version returns version and build information.`,
 		Run: func(c *cobra.Command, args []string) {
-			fmt.Printf("elastic-agent-shipper\tversion: %s\n", tools.GetDefaultVersion())
-			fmt.Printf("\tbuild_commit: %s\tbuild_time: %s\tsnapshot_build: %v\n", tools.Commit(), tools.BuildTime(), tools.Snapshot())
+			fmt.Fprintf(os.Stdout, "elastic-agent-shipper\tversion: %s\n", tools.GetDefaultVersion())
+			fmt.Fprintf(os.Stdout, "\tbuild_commit: %s\tbuild_time: %s\tsnapshot_build: %v\n", tools.Commit(), tools.BuildTime(), tools.Snapshot())
 		},
 	}
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -8,8 +8,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/elastic/elastic-agent-shipper/tools"
 	"github.com/spf13/cobra"
+
+	"github.com/elastic/elastic-agent-shipper/tools"
 )
 
 func newVersionCommand() *cobra.Command {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,26 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/elastic/elastic-agent-shipper/tools"
+	"github.com/spf13/cobra"
+)
+
+func newVersionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Version returns version and build information.",
+		Long:  `Version returns version and build information.`,
+		Run: func(c *cobra.Command, args []string) {
+			fmt.Printf("elastic-agent-shipper\tversion: %s\n", tools.GetDefaultVersion())
+			fmt.Printf("\tbuild_commit: %s\tbuild_time: %s\tsnapshot_build: %v\n", tools.Commit(), tools.BuildTime(), tools.Snapshot())
+		},
+	}
+
+	return cmd
+}

--- a/tools/helper.go
+++ b/tools/helper.go
@@ -1,0 +1,47 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package tools
+
+import (
+	"strconv"
+	"time"
+)
+
+var (
+	commit    string
+	buildTime string
+	qualifier string
+	snapshot  string
+)
+
+// GetDefaultVersion returns the current libbeat version.
+// This method is in a separate file as the version.go file is auto generated
+func GetDefaultVersion() string {
+	if qualifier == "" {
+		return DefaultBeatVersion
+	}
+	return DefaultBeatVersion + "-" + qualifier
+}
+
+// BuildTime exposes the compile-time build time information.
+// It will represent the zero time instant if parsing fails.
+func BuildTime() time.Time {
+	t, err := time.Parse(time.RFC3339, buildTime)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// Commit exposes the compile-time commit hash.
+func Commit() string {
+	return commit
+}
+
+// Snapshot returns true if binary was compiled as a SNAPSHOT build
+func Snapshot() bool {
+	val, err := strconv.ParseBool(snapshot)
+	return err == nil && val
+}


### PR DESCRIPTION
This PR adds versioning information and `version` subcommand.
Sample output 

<img width="953" alt="image" src="https://user-images.githubusercontent.com/1522652/200515832-36294f4c-8c8b-4d6a-87c8-77a8207dec1a.png">

Related: #113 