### PR TITLE
Add support for codecs

### DIFF
--- a/output/kafka/config.go
+++ b/output/kafka/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/fmtstr"
 	libkafka "github.com/elastic/beats/v7/libbeat/common/kafka"
 	"github.com/elastic/beats/v7/libbeat/common/transport/kerberos"
+	"github.com/elastic/beats/v7/libbeat/outputs/codec"
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/monitoring"
@@ -62,9 +63,7 @@ type Config struct {
 	Password           string                    `config:"password"`
 	Sasl               libkafka.SaslConfig       `config:"sasl"`
 	EnableFAST         bool                      `config:"enable_krb5_fast"`
-	// TODO: Figure out codecs
-	//Codec              codec.Config              `config:"codec"`
-
+	Codec              codec.Config              `config:"codec"`
 }
 
 type MetaConfig struct {

--- a/output/kafka/kafka.go
+++ b/output/kafka/kafka.go
@@ -7,8 +7,11 @@ package kafka
 import (
 	"github.com/Shopify/sarama"
 
-	"github.com/elastic/beats/v7/libbeat/outputs/codec/json"
-
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/outputs/codec"
+	_ "github.com/elastic/beats/v7/libbeat/outputs/codec/format"
+	_ "github.com/elastic/beats/v7/libbeat/outputs/codec/json"
+	"github.com/elastic/beats/v7/libbeat/version"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
@@ -45,18 +48,12 @@ func makeKafka(
 
 	hosts := config.Hosts
 
-	// TODO: Fix encoding
-	codec := json.New("1", json.Config{
-		Pretty:     true,
-		EscapeHTML: true,
-	})
+	beatInfo := beat.Info{Version: version.GetDefaultVersion()}
 
-	//codec, err := codec.CreateEncoder(beat, config.Codec)
-	//if err != nil {
-	//	fmt.Println("failed %v", err)
-	//	return nil, nil
-	//	//return outputs.Fail(err)
-	//}
+	codec, err := codec.CreateEncoder(beatInfo, config.Codec)
+	if err != nil {
+		return nil, err
+	}
 
 	return newKafkaClient( /*observer, */ hosts, "kafka", config.Key, topic, config.Headers, codec, libCfg)
 

--- a/output/kafka/kafka.go
+++ b/output/kafka/kafka.go
@@ -48,6 +48,9 @@ func makeKafka(
 
 	hosts := config.Hosts
 
+	// The construction of the encoder requires a `beat.Info` object to be present
+	// As far as I can tell, the only property used is the version, which is used
+	// to populate metadata in the json encoder
 	beatInfo := beat.Info{Version: version.GetDefaultVersion()}
 
 	codec, err := codec.CreateEncoder(beatInfo, config.Codec)


### PR DESCRIPTION
This commit adds support for codecs in the configuration file with the same syntax and options as the beats kafka output.

This commit creates a `BeatInfo` object to pass into the existing codec object AFAICT, this only requires a version to populate metadata with.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.md` or `CHANGELOG-developer.md`.~~

Closes #165
