### PR TITLE
[Release] Update version to 8.6.1

### DIFF
--- a/tools/version.go
+++ b/tools/version.go
@@ -4,4 +4,4 @@
 
 package tools
 
-const DefaultBeatVersion = "8.6.0"
+const DefaultBeatVersion = "8.6.1"


### PR DESCRIPTION
Updates references to the new release 8.6.1.

Merge after the release 8.6.0.