### PR TITLE
Remove deprecated CI option

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -49,8 +49,5 @@ jobs:
           # into fixing all linting issues in the whole file instead
           args: --timeout=30m --whole-files
 
-          # Optional: if set to true then the action will use pre-installed Go.
-          skip-go-installation: true
-
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true


### PR DESCRIPTION
Remove the `skip-go-installation` flag from the CI since it has [been removed](https://github.com/golangci/golangci-lint-action) and is causing spurious linter warnings.
