### PR TITLE
Include tags in checkouts to fix release builds.

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
       steps {
         pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
+        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true, shallow: false, noTags: false)
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         dir("${BASE_DIR}"){
           setEnvVar('GO_VERSION', readFile(".go-version").trim())


### PR DESCRIPTION
Back when the 8.6 branch was forked, all of the builds were failing with an error like that in https://fleet-ci.elastic.co/job/elastic-agent-shipper-mbp/job/8.6/4/:

```
14:00:35     • getting and validating git state
14:00:35        • running git               args=[-c log.showSignature=false ls-remote --get-url]
14:00:35        • git result                stderr= stdout=git@github.com:elastic/elastic-agent-shipper.git
14:00:35  
14:00:35        • running git               args=[-c log.showSignature=false tag --points-at HEAD --sort -version:refname]
14:00:35        • git result                stderr= stdout=
14:00:35        • running git               args=[-c log.showSignature=false describe --tags --abbrev=0]
14:00:35        • git result                stderr=fatal: No tags can describe 'f9c5d88cbc05236728a444af72ed4b63969b0d81'.
```

I fixed this directly on the 8.6 branch by ensuring we include tags in the Git checkout step. This PR is just porting that change back to main to fix this for future release branches.
