### PR TITLE
Proper naming of included archive directory

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -333,7 +333,7 @@ func (Package) Artifacts() {
 		// prepare package
 		var err error
 		var archiveFileName string
-		targetDir := fmt.Sprintf("%s-%s", devtools.ProjectName, platform)
+		targetDir := fmt.Sprintf("%s-%s-%s", devtools.ProjectName, version, platform)
 		if isWindows {
 			archiveFileName = fmt.Sprintf("%s-%s-%s.zip", devtools.ProjectName, version, platform)
 			err = prepareZipArchive(


### PR DESCRIPTION
Included directory inside an archive has invalid name resulting in shipper not being bundled with elastic agent

Name had no version information included

 ```
>> tar -xzf elastic-agent-shipper-8.7.0-SNAPSHOT-linux-x86.tar.gz
>> ls
elastic-agent-shipper-8.7.0-SNAPSHOT-linux-x86.tar.gz
elastic-agent-shipper-linux-x86 
```

after:

 ```
>> tar -xzf elastic-agent-shipper-8.7.0-SNAPSHOT-linux-x86.tar.gz
>> ls
elastic-agent-shipper-8.7.0-SNAPSHOT-linux-x86.tar.gz
elastic-agent-shipper-8.7.0-SNAPSHOT-linux-x86
```