### PR TITLE
Add config fields + defaults to the Elasticsearch output

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -643,11 +643,11 @@ these terms.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/go-elasticsearch/v8
-Version: v8.2.0
+Version: v8.6.0
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/go-elasticsearch/v8@v8.2.0/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/go-elasticsearch/v8@v8.6.0/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/elastic-agent-shipper.yml
+++ b/elastic-agent-shipper.yml
@@ -134,6 +134,11 @@ output:
     #batch_size: 10000000
     #flush_timeout: 30s
 
+    #retry_on_http_status: [502, 503, 504]
+    #max_retries: 5
+    #backoff.init: 1s
+    #backoff.max: 60s
+
     # This option may be convenient for local testing:
     #ssl.verification_mode: none
 

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/eapache/go-resiliency v1.2.0
 	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20220810153818-dd118efed5a5
 	github.com/elastic/elastic-agent-client/v7 v7.0.1
-	github.com/elastic/go-elasticsearch/v8 v8.6.0
 	github.com/elastic/elastic-agent-shipper-client v0.5.0
+	github.com/elastic/go-elasticsearch/v8 v8.6.0
 	github.com/elastic/go-lumber v0.1.1
 	github.com/elastic/go-ucfg v0.8.6 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/elastic/elastic-transport-go/v8 v8.1.0 // indirect
+	github.com/elastic/go-elasticsearch v0.0.0 // indirect
 	github.com/elastic/go-licenser v0.4.1 // indirect
 	github.com/elastic/go-structform v0.0.10 // indirect
 	github.com/elastic/go-sysinfo v1.8.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20220810153818-dd118efed5a5
 	github.com/elastic/elastic-agent-client/v7 v7.0.1
 	github.com/elastic/elastic-agent-shipper-client v0.4.1-0.20221028153110-a7eedbe6bd6c
-	github.com/elastic/go-elasticsearch/v8 v8.2.0
+	github.com/elastic/go-elasticsearch/v8 v8.6.0
 	github.com/elastic/go-lumber v0.1.1
 	github.com/elastic/go-ucfg v0.8.6 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible
@@ -38,7 +38,6 @@ require (
 	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/elastic/elastic-transport-go/v8 v8.1.0 // indirect
-	github.com/elastic/go-elasticsearch v0.0.0 // indirect
 	github.com/elastic/go-licenser v0.4.1 // indirect
 	github.com/elastic/go-structform v0.0.10 // indirect
 	github.com/elastic/go-sysinfo v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -508,13 +508,14 @@ github.com/elastic/elastic-agent-shipper-client v0.2.0/go.mod h1:OyI2W+Mv3JxlkEF
 github.com/elastic/elastic-agent-shipper-client v0.4.1-0.20221028153110-a7eedbe6bd6c h1:jgoz/UHtf6QunIwe8DmeQb0lq6y0jFsPO9rCA0l/cRY=
 github.com/elastic/elastic-agent-shipper-client v0.4.1-0.20221028153110-a7eedbe6bd6c/go.mod h1:OyI2W+Mv3JxlkEF3OeT7K0dbuxvwew8ke2Cf4HpLa9Q=
 github.com/elastic/elastic-agent-system-metrics v0.4.4/go.mod h1:tF/f9Off38nfzTZHIVQ++FkXrDm9keFhFpJ+3pQ00iI=
+github.com/elastic/elastic-transport-go/v8 v8.0.0-20211216131617-bbee439d559c/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=
 github.com/elastic/elastic-transport-go/v8 v8.1.0 h1:NeqEz1ty4RQz+TVbUrpSU7pZ48XkzGWQj02k5koahIE=
 github.com/elastic/elastic-transport-go/v8 v8.1.0/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=
 github.com/elastic/go-concert v0.2.0/go.mod h1:HWjpO3IAEJUxOeaJOWXWEp7imKd27foxz9V5vegC/38=
-github.com/elastic/go-elasticsearch v0.0.0 h1:Pd5fqOuBxKxv83b0+xOAJDAkziWYwFinWnBO0y+TZaA=
-github.com/elastic/go-elasticsearch v0.0.0/go.mod h1:TkBSJBuTyFdBnrNqoPc54FN0vKf5c04IdM4zuStJ7xg=
 github.com/elastic/go-elasticsearch/v8 v8.2.0 h1:oagGcb1gqxT7yWpQ3E7wMP3NhGRamsKVd7kRdbuI+/Y=
 github.com/elastic/go-elasticsearch/v8 v8.2.0/go.mod h1:yY52i2Vj0unLz+N3Nwx1gM5LXwoj3h2dgptNGBYkMLA=
+github.com/elastic/go-elasticsearch/v8 v8.6.0 h1:xMaSe8jIh7NHzmNo9YBkewmaD2Pr+tX+zLkXxhieny4=
+github.com/elastic/go-elasticsearch/v8 v8.6.0/go.mod h1:Usvydt+x0dv9a1TzEUaovqbJor8rmOHy5dSmPeMAE2k=
 github.com/elastic/go-libaudit/v2 v2.3.2-0.20220729123722-f8f7d5c19e6b/go.mod h1:+ZE0czqmbqtnRkl0fNgpI+HvVVRo/ZMJdcXv/PaKcOo=
 github.com/elastic/go-licenser v0.4.0/go.mod h1:V56wHMpmdURfibNBggaSBfqgPxyT1Tldns1i87iTEvU=
 github.com/elastic/go-licenser v0.4.1 h1:1xDURsc8pL5zYT9R29425J3vkHdt4RT5TNEMeRN48x4=

--- a/go.sum
+++ b/go.sum
@@ -511,6 +511,8 @@ github.com/elastic/elastic-agent-system-metrics v0.4.4/go.mod h1:tF/f9Off38nfzTZ
 github.com/elastic/elastic-transport-go/v8 v8.1.0 h1:NeqEz1ty4RQz+TVbUrpSU7pZ48XkzGWQj02k5koahIE=
 github.com/elastic/elastic-transport-go/v8 v8.1.0/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=
 github.com/elastic/go-concert v0.2.0/go.mod h1:HWjpO3IAEJUxOeaJOWXWEp7imKd27foxz9V5vegC/38=
+github.com/elastic/go-elasticsearch v0.0.0 h1:Pd5fqOuBxKxv83b0+xOAJDAkziWYwFinWnBO0y+TZaA=
+github.com/elastic/go-elasticsearch v0.0.0/go.mod h1:TkBSJBuTyFdBnrNqoPc54FN0vKf5c04IdM4zuStJ7xg=
 github.com/elastic/go-elasticsearch/v8 v8.2.0 h1:oagGcb1gqxT7yWpQ3E7wMP3NhGRamsKVd7kRdbuI+/Y=
 github.com/elastic/go-elasticsearch/v8 v8.2.0/go.mod h1:yY52i2Vj0unLz+N3Nwx1gM5LXwoj3h2dgptNGBYkMLA=
 github.com/elastic/go-libaudit/v2 v2.3.2-0.20220729123722-f8f7d5c19e6b/go.mod h1:+ZE0czqmbqtnRkl0fNgpI+HvVVRo/ZMJdcXv/PaKcOo=

--- a/go.sum
+++ b/go.sum
@@ -512,7 +512,6 @@ github.com/elastic/elastic-transport-go/v8 v8.0.0-20211216131617-bbee439d559c/go
 github.com/elastic/elastic-transport-go/v8 v8.1.0 h1:NeqEz1ty4RQz+TVbUrpSU7pZ48XkzGWQj02k5koahIE=
 github.com/elastic/elastic-transport-go/v8 v8.1.0/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=
 github.com/elastic/go-concert v0.2.0/go.mod h1:HWjpO3IAEJUxOeaJOWXWEp7imKd27foxz9V5vegC/38=
-github.com/elastic/go-elasticsearch/v8 v8.2.0 h1:oagGcb1gqxT7yWpQ3E7wMP3NhGRamsKVd7kRdbuI+/Y=
 github.com/elastic/go-elasticsearch/v8 v8.2.0/go.mod h1:yY52i2Vj0unLz+N3Nwx1gM5LXwoj3h2dgptNGBYkMLA=
 github.com/elastic/go-elasticsearch/v8 v8.6.0 h1:xMaSe8jIh7NHzmNo9YBkewmaD2Pr+tX+zLkXxhieny4=
 github.com/elastic/go-elasticsearch/v8 v8.6.0/go.mod h1:Usvydt+x0dv9a1TzEUaovqbJor8rmOHy5dSmPeMAE2k=

--- a/output/elasticsearch/config.go
+++ b/output/elasticsearch/config.go
@@ -53,13 +53,16 @@ type Config struct {
 	// Defaults to 30sec.
 	FlushTimeout time.Duration `config:"flush_timeout"`
 
+	// The following are internal parameters of the output that are not used
+	// by go-elasticsearch:
+
 	DegradedTimeout time.Duration `config:"degraded_timeout"`
 }
 
 // Backoff represents connection backoff settings
 type Backoff struct {
-	Init time.Duration
-	Max  time.Duration
+	Init time.Duration `config:"init"`
+	Max  time.Duration `config:"max"`
 }
 
 func (b Backoff) delayTime(attempt int) time.Duration {

--- a/output/elasticsearch/config.go
+++ b/output/elasticsearch/config.go
@@ -7,6 +7,7 @@ package elasticsearch
 import (
 	"crypto/tls"
 	"net/http"
+	"runtime"
 	"time"
 
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
@@ -18,33 +19,30 @@ import (
 // Currently these are identical to the parameters in the Beats Elasticsearch
 // output, however this is subject to change as we approach official release.
 type Config struct {
-	Enabled  bool     `config:"enabled"`
+	Enabled bool `config:"enabled"`
+
+	// The following parameters map more-or-less directly to values in the
+	// go-elasticsearch config, and are converted in the esConfig()
+	// helper:
+
 	Hosts    []string `config:"hosts"`
 	Username string   `config:"username"`
 	Password string   `config:"password"`
 
-	Backoff    Backoff `config:"backoff"`
-	MaxRetries int     `config:"max_retries"`
+	// Default: {init: 1sec, max: 60sec}
+	Backoff Backoff `config:"backoff"`
+
+	// Default: 3
+	MaxRetries int `config:"max_retries"`
+
+	// Default: 502, 503, 504.
+	RetryOnHTTPStatus []int `config:"retry_on_http_status"`
 
 	Transport httpcommon.HTTPTransportSettings `config:",inline"`
 
-	// The following configuration flags are copied from the equivalent Beats
-	// configuration, but are commented out because they are not yet active/implemented:
-	//Protocol           string            `config:"protocol"`
-	//Path               string            `config:"path"`
-	//Params             map[string]string `config:"parameters"`
-	//Headers            map[string]string `config:"headers"`
-	//APIKey             string            `config:"api_key"`
-	//LoadBalance        bool              `config:"loadbalance"`
-	//CompressionLevel   int               `config:"compression_level" validate:"min=0, max=9"`
-	//EscapeHTML         bool              `config:"escape_html"`
-	//Kerberos           *kerberos.Config  `config:"kerberos"`
-	//NonIndexablePolicy *config.Namespace `config:"non_indexable_policy"`
-	//AllowOlderVersion  bool              `config:"allow_older_versions"`
-
 	// The following parameters have no equivalent in the go-elasticsearch
 	// config, and need to be specified directly when the indexer is created
-	// instead of being returned in esConfig().
+	// instead of being returned in esConfig():
 
 	// Defaults to runtime.NumCPU()
 	NumWorkers int `config:"num_workers"`
@@ -80,9 +78,35 @@ func (c *Config) Validate() error {
 	return nil
 }
 
+func (c Config) addDefaults() Config {
+	if c.Backoff.Init == 0 {
+		c.Backoff.Init = 1 * time.Second
+	}
+	if c.Backoff.Max == 0 {
+		c.Backoff.Max = 60 * time.Second
+	}
+	if len(c.RetryOnHTTPStatus) == 0 {
+		c.RetryOnHTTPStatus = []int{502, 503, 504}
+	}
+	if c.MaxRetries == 0 {
+		c.MaxRetries = 3
+	}
+	if c.NumWorkers == 0 {
+		c.NumWorkers = runtime.NumCPU()
+	}
+	if c.BatchSize == 0 {
+		c.BatchSize = 5 * (1 << 20) // 5MB
+	}
+	if c.FlushTimeout == 0 {
+		c.FlushTimeout = 30 * time.Second
+	}
+	return c
+}
+
 // esConfig converts the configuration for the elasticsearch shipper output
 // to the configuration for the go-elasticsearch client API.
 func (c Config) esConfig() elasticsearch.Config {
+	c = c.addDefaults()
 	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
 	if c.Transport.TLS != nil && c.Transport.TLS.VerificationMode == tlscommon.VerifyNone {
 		// Unlike Beats, the shipper doesn't support the ability to verify the
@@ -91,11 +115,12 @@ func (c Config) esConfig() elasticsearch.Config {
 		tlsConfig.InsecureSkipVerify = true
 	}
 	cfg := elasticsearch.Config{
-		Addresses:    c.Hosts,
-		Username:     c.Username,
-		Password:     c.Password,
-		RetryBackoff: c.Backoff.delayTime,
-		MaxRetries:   c.MaxRetries,
+		Addresses:     c.Hosts,
+		Username:      c.Username,
+		Password:      c.Password,
+		RetryBackoff:  c.Backoff.delayTime,
+		MaxRetries:    c.MaxRetries,
+		RetryOnStatus: c.RetryOnHTTPStatus,
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
 		},

--- a/output/elasticsearch/output.go
+++ b/output/elasticsearch/output.go
@@ -72,7 +72,7 @@ func (es *ElasticSearchOutput) Start() error {
 	go func() {
 		defer es.wg.Done()
 		for {
-			batch, err := es.queue.Get(1000)
+			batch, err := es.queue.Get(100)
 			// Once an output receives a batch, it is responsible for
 			// it until all events have been either successfully sent or
 			// discarded after failure.


### PR DESCRIPTION
Support more timeout / retry options in the Elasticsearch shipper output and make the existing defaults more explicit, per https://github.com/elastic/elastic-agent-shipper/issues/151.

Resolves https://github.com/elastic/elastic-agent-shipper/issues/151

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.md` or `CHANGELOG-developer.md`.~~
