### PR TITLE
Pass raw_index through to the ES indexer

### DIFF
--- a/output/elasticsearch/output.go
+++ b/output/elasticsearch/output.go
@@ -109,6 +109,8 @@ func (es *ElasticSearchOutput) Start() error {
 					continue
 				}
 				var rawIndex string
+				// If the event metadata contains a raw_index field, attach
+				// that to the indexer item to override the global default.
 				if indexField := event.GetMetadata().GetData()["raw_index"]; indexField != nil {
 					rawIndex = indexField.GetStringValue()
 				}

--- a/output/elasticsearch/output.go
+++ b/output/elasticsearch/output.go
@@ -108,10 +108,15 @@ func (es *ElasticSearchOutput) Start() error {
 					es.logger.Errorf("failed to serialize event: %v", err)
 					continue
 				}
+				var rawIndex string
+				if indexField := event.GetMetadata().GetData()["raw_index"]; indexField != nil {
+					rawIndex = indexField.GetStringValue()
+				}
 				err = bi.Add(
 					context.Background(),
 					esutil.BulkIndexerItem{
 						Action: "index",
+						Index:  rawIndex,
 						Body:   bytes.NewReader(serialized),
 						OnSuccess: func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem) {
 							// TODO: update metrics


### PR DESCRIPTION
Propagates the tagged index to the `go-elasticsearch` indexer (when present) instead of using a hard-coded default.

Resolves https://github.com/elastic/elastic-agent-shipper/issues/202

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.md` or `CHANGELOG-developer.md`.~~
