### PR TITLE
Fix test under darwin

### DIFF
--- a/controller/run.go
+++ b/controller/run.go
@@ -71,6 +71,9 @@ func RunUnmanaged(ctx context.Context, cfg config.ShipperRootConfig) error {
 
 	srv := grpcserver.NewGRPCServer(runner)
 	err = srv.Start(creds, cfg.Shipper.Server.Server)
+	if err != nil {
+		return fmt.Errorf("error starting grpc server: %w", err)
+	}
 
 	// On termination signals, gracefully stop the shipper
 	sigc := make(chan os.Signal, 1)

--- a/controller/run_test.go
+++ b/controller/run_test.go
@@ -49,6 +49,11 @@ func TestUnmanaged(t *testing.T) {
 			break
 		}
 	}
+	// remove the file now that we know it's there
+	defer func() {
+		_ = os.Remove(serverAddr)
+	}()
+
 	// basic test, make sure output is running
 	con, err := net.Dial("unix", serverAddr)
 	require.NoError(t, err)


### PR DESCRIPTION
## What does this PR do?

This fixes an issue with the `TestUnmanaged` test failing on Darwin, as the filename was too long. This also makes the test _not_ rely on a timer, and instead waits until the unix socket is available.

This also fixes a missing error check in `RunUnmanaged()`

## Why is it important?
This is causing test failures.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md` or `CHANGELOG-developer.md`.
