### PR TITLE
change to v2 spec file

### DIFF
--- a/elastic-agent-shipper.spec.yml
+++ b/elastic-agent-shipper.spec.yml
@@ -18,4 +18,4 @@ shippers:
     command: &command
       args:
         - "-E"
-        - "logging.level=debug"
+        - "logging.level=info"

--- a/elastic-agent-shipper.spec.yml
+++ b/elastic-agent-shipper.spec.yml
@@ -1,8 +1,8 @@
 version: 2
-outputs:
-  - name: elasticsearch
-    description: Elasticsearch
-    platforms: &platforms
+shippers:
+  - name: shipper
+    description: "Elastic Agent Shipper"
+    platforms:
       - linux/amd64
       - linux/arm64
       - darwin/amd64
@@ -10,5 +10,12 @@ outputs:
       - windows/amd64
       - container/amd64
       - container/arm64
-    command: {}
-  
+    outputs:
+      - elasticsearch
+      - kafka
+      - logstash
+      - redis
+    command: &command
+      args:
+        - "-E"
+        - "logging.level=debug"


### PR DESCRIPTION
## What does this PR do?

Updates the spec file to version 2

## Why is it important?

shipper can't be started by elastic-agent without the correct version
of the spec file

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.md` or `CHANGELOG-developer.md`.~~

## How to test this PR locally

Build elastic-agent with shipper built with this PR.  Should be able
to start shipper under agent with:

``` yaml
outputs:
  default:
    type: elasticsearch
    password: '<password here>'
    username: elastic
    hosts:
      - 'https://<hostname>:443'
    shipper:
      enabled: true
```

## Related issues

- Closes #222