### PR TITLE
Improve error message on index failure

### DIFF
--- a/output/elasticsearch/output.go
+++ b/output/elasticsearch/output.go
@@ -133,8 +133,9 @@ func (es *ElasticSearchOutput) Start() error {
 						},
 						OnFailure: func(ctx context.Context, item esutil.BulkIndexerItem, res esutil.BulkIndexerResponseItem, err error) {
 							// TODO: update metrics
-							es.healthWatcher.Fail(res.Error.Cause.Reason)
-							es.logger.Debugf("Failed to add items: %#v", res.Error.Cause.Reason)
+							errMsg := fmt.Sprintf("err: %s cause: %s", res.Error.Reason, res.Error.Cause.Reason)
+							es.healthWatcher.Fail(errMsg)
+							es.logger.Debugf("Failed to add items: %#v", errMsg)
 							batch.Done(1)
 
 						},


### PR DESCRIPTION
## What does this PR do?

Small change to improve error message. On certain events, `res.Error.Cause.Reason`, but `res.Error.Reason` won't be. Log both error types, just in case.

## Why is it important?

Can result in some unhelpful `"Error: ""` messages.
