### PR TITLE
Add custom event encoder for Elasticsearch output 

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -540,11 +540,11 @@ Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-l
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/elastic-agent-shipper-client
-Version: v0.5.1-0.20230228231646-f04347b666f3
+Version: v0.5.1-0.20230301154434-a10074360f12
 Licence type (autodetected): Elastic
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-shipper-client@v0.5.1-0.20230228231646-f04347b666f3/LICENSE.txt:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-shipper-client@v0.5.1-0.20230301154434-a10074360f12/LICENSE.txt:
 
 Elastic License 2.0
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/eapache/go-resiliency v1.2.0
 	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20220810153818-dd118efed5a5
 	github.com/elastic/elastic-agent-client/v7 v7.0.1
-	github.com/elastic/elastic-agent-shipper-client v0.5.1-0.20230228231646-f04347b666f3
+	github.com/elastic/elastic-agent-shipper-client v0.5.1-0.20230301154434-a10074360f12
 	github.com/elastic/go-elasticsearch/v8 v8.6.0
 	github.com/elastic/go-lumber v0.1.1
 	github.com/elastic/go-ucfg v0.8.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/elastic/elastic-agent-client/v7 v7.0.1 h1:RDiozMRkjVfsn1vZ5tc1YzRC+g4
 github.com/elastic/elastic-agent-client/v7 v7.0.1/go.mod h1:cHviLpA5fAwMbfBIHBVNl16qp90bO7pKHMAQaG+9raU=
 github.com/elastic/elastic-agent-libs v0.3.3 h1:iE8XhqQ0zRBLba+eu6ScZED0DYcVP/r2JvjcVoOkxic=
 github.com/elastic/elastic-agent-libs v0.3.3/go.mod h1:nRkcK96PSJfK232cJRx17n9+/MVAIOzs5ghZdzXJAMo=
-github.com/elastic/elastic-agent-shipper-client v0.5.1-0.20230228231646-f04347b666f3 h1:sb+25XJn/JcC9/VL8HX4r4QXSUq4uTNzGS2kxOE7u1U=
-github.com/elastic/elastic-agent-shipper-client v0.5.1-0.20230228231646-f04347b666f3/go.mod h1:rWarFM7qYxJKsi9WcV6ONcFjH/NA3niDNpTxO+8/GVI=
+github.com/elastic/elastic-agent-shipper-client v0.5.1-0.20230301154434-a10074360f12 h1:6otnvaYs4+6S9Xw332vBjMrAQdkaT9kRnyO0flEfC6A=
+github.com/elastic/elastic-agent-shipper-client v0.5.1-0.20230301154434-a10074360f12/go.mod h1:rWarFM7qYxJKsi9WcV6ONcFjH/NA3niDNpTxO+8/GVI=
 github.com/elastic/elastic-transport-go/v8 v8.0.0-20211216131617-bbee439d559c/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=
 github.com/elastic/elastic-transport-go/v8 v8.1.0 h1:NeqEz1ty4RQz+TVbUrpSU7pZ48XkzGWQj02k5koahIE=
 github.com/elastic/elastic-transport-go/v8 v8.1.0/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=

--- a/output/elasticsearch/event.go
+++ b/output/elasticsearch/event.go
@@ -1,0 +1,52 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package elasticsearch
+
+import (
+	"fmt"
+	"time"
+
+	"go.elastic.co/fastjson"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/elastic/elastic-agent-shipper-client/pkg/proto/messages"
+)
+
+// Event is a wrapper type for beat events
+// the events that ES expects contain an @timestamp at the root evel
+type Event struct {
+	Timestamp *timestamppb.Timestamp
+	Fields    *messages.Struct
+}
+
+// MarshalFastJSON implements the JSON interface for the main event type
+func (evt *Event) MarshalFastJSON(w *fastjson.Writer) error {
+	w.RawByte('{')
+	w.RawString("\"@timestamp\":")
+	w.RawByte('"')
+	w.Time(evt.Timestamp.AsTime(), time.RFC3339Nano)
+	w.RawByte('"')
+
+	if evt.Fields != nil {
+		w.RawByte(',')
+		beginning := true
+		for key, val := range evt.Fields.GetData() {
+			if !beginning {
+				w.RawByte(',')
+			} else {
+				beginning = false
+			}
+
+			w.RawString(fmt.Sprintf("\"%s\":", key))
+			err := val.MarshalFastJSON(w)
+			if err != nil {
+				return fmt.Errorf("error marshaling value in map: %w", err)
+			}
+		}
+	}
+
+	w.RawByte('}')
+	return nil
+}

--- a/output/elasticsearch/event_test.go
+++ b/output/elasticsearch/event_test.go
@@ -10,10 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/elastic-agent-shipper-client/pkg/helpers"
 	"github.com/stretchr/testify/require"
 	"go.elastic.co/fastjson"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/elastic/elastic-agent-shipper-client/pkg/helpers"
 )
 
 func TestEventMarshal(t *testing.T) {

--- a/output/elasticsearch/event_test.go
+++ b/output/elasticsearch/event_test.go
@@ -1,0 +1,54 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package elasticsearch
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/elastic/elastic-agent-shipper-client/pkg/helpers"
+	"github.com/stretchr/testify/require"
+	"go.elastic.co/fastjson"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestEventMarshal(t *testing.T) {
+	evt := Event{}
+	ts := time.Now().UTC()
+	fields, err := helpers.NewStruct(map[string]interface{}{
+		"testval": "test",
+		"data":    3,
+		"map": map[string]interface{}{
+			"nested": true,
+		},
+	})
+	require.NoError(t, err)
+	evt.Fields = fields
+	evt.Timestamp = timestamppb.New(ts)
+
+	expectedEvent := map[string]interface{}{
+		"@timestamp": ts.Format(time.RFC3339Nano),
+		"testval":    "test",
+		"data":       float64(3),
+		"map": map[string]interface{}{
+			"nested": true,
+		},
+	}
+
+	jsonWriter := &fastjson.Writer{}
+	err = fastjson.Marshal(jsonWriter, &evt)
+	require.NoError(t, err)
+
+	// make sure it's valid JSON
+	parsedEvt := map[string]interface{}{}
+	err = json.Unmarshal(jsonWriter.Bytes(), &parsedEvt)
+	require.NoError(t, err)
+	if !reflect.DeepEqual(expectedEvent, parsedEvt) {
+		t.Logf("expected equal events, got: ")
+		require.Equal(t, expectedEvent, parsedEvt)
+	}
+}

--- a/output/elasticsearch/output.go
+++ b/output/elasticsearch/output.go
@@ -53,7 +53,8 @@ func serializeEvent(event *messages.Event) ([]byte, error) {
 	// right place for ECS. This just translates the protobuf structure
 	// directly to json.
 	jsonWriter := &fastjson.Writer{}
-	err := fastjson.Marshal(jsonWriter, event.GetFields())
+	evt := Event{Timestamp: event.GetTimestamp(), Fields: event.GetFields()}
+	err := fastjson.Marshal(jsonWriter, &evt)
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling event to json: %w", err)
 	}


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/elastic/elastic-agent-shipper/issues/256
Fixes https://github.com/elastic/elastic-agent-shipper/issues/253

This adds a custom `Event` type along with the fastjson implementation in order to correctly add a `@timestamp` field to events. This is something the Beats elasticsearch output already does, and presumably went unnoticed as the logic is buried in a special little encoder callback. 

## Why is it important?

We need a `@timestamp` field.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md` or `CHANGELOG-developer.md`.
