### PR TITLE
Remove check for global log level in test

### DIFF
--- a/controller/controller_client_test.go
+++ b/controller/controller_client_test.go
@@ -486,7 +486,6 @@ func TestBasicAgentControl(t *testing.T) {
 func TestUnitLogChange(t *testing.T) {
 	token := mock.NewID()
 	var gotConfig, gotHealthy, gotStopped, gotRestarted bool
-	var observedLogLevel zapcore.Level
 
 	var mut sync.Mutex
 	_ = logp.DevelopmentSetup()
@@ -541,7 +540,6 @@ func TestUnitLogChange(t *testing.T) {
 				// shut down
 				t.Logf("Got unit state healthy, stopping")
 				//check to see if log level has changed
-				observedLogLevel = logp.GetLevel()
 				unitOut.ConfigStateIdx++
 				unitOut.State = proto.State_STOPPED
 				return &proto.CheckinExpected{
@@ -572,7 +570,6 @@ func TestUnitLogChange(t *testing.T) {
 	assert.True(t, gotHealthy, "healthy state")
 	assert.True(t, gotStopped, "stopped state")
 	assert.False(t, gotRestarted, "units restarted")
-	assert.Equal(t, zapcore.DebugLevel, observedLogLevel, "not expected log level")
 
 }
 


### PR DESCRIPTION
This removes a check of the global log level from one of the shipper tests; this is causing some flakiness, and it's probably rather optimistic to assume that we can arbitrarily check a global variable without running into some kind of conflict is rather optimistic.
