### PR TITLE
updatecli: use composite action and delete branches

### DIFF
--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -1,5 +1,6 @@
 ---
 name: Bump golang-version to latest version
+pipelineid: 'bump-golang-version'
 
 scms:
   githubConfig:
@@ -21,9 +22,12 @@ actions:
     spec:
       automerge: false
       labels:
+        - automation
         - dependencies
         - backport-skip
       title: '[Automation] Bump Golang version to {{ source "latestGoVersion" }}'
+      description: |
+        See [changelog](https://github.com/golang/go/issues?q=milestone%3AGo{{ source "latestGoVersion" }}+label%3ACherryPickApproved) for {{ source "latestGoVersion" }}
 
 sources:
   minor:

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -1,14 +1,12 @@
 ---
 name: Bump golang version
-
 on:
   workflow_dispatch:
   schedule:
     - cron: '0 20 * * 6'
 
 permissions:
-  pull-requests: write
-  contents: write
+  contents: read
 
 jobs:
   bump:
@@ -17,13 +15,10 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - name: Setup Git
-        uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
+      - uses: elastic/apm-pipeline-library/.github/actions/updatecli@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          pipeline: ./.ci/bump-golang.yml
 
-      - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@453502948b442d7b9a923de7b40cc7ce8628505c
-
-      - name: Run Updatecli
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: updatecli apply --config ./.ci/bump-golang.yml

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -36,7 +36,7 @@ pull_request_rules:
         - closed
       - and:
         - label=automation
-        - head~=^update-go-version
+        - head~=^updatecli
         - files~=^\.go-version$
     actions:
       delete_head_branch:


### PR DESCRIPTION
## What does this PR do?

Use the composite action defined in https://github.com/elastic/apm-pipeline-library/tree/main/.github/actions/updatecli
Delete branches once their PRs have been merged/closed
Add description with the Golang changelog.


## Why is it important?

Use a service account so GitHub actions can work correctly, otherwise nested GitHub actions won't work when their original creator is the GitHub action bot.
Reduce the overhead to delete branches.