### PR TITLE
Propagate the mage verbose flag to gorelease

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -83,6 +83,9 @@ func (Build) Binary() error {
 	InstallGoReleaser()
 
 	args := []string{"build", "--rm-dist", "--skip-validate"}
+	if mg.Verbose() {
+		args = append(args, "--debug")
+	}
 	// Environment variable
 	env := map[string]string{
 		"CGO_ENABLED":     devtools.EnvOrDefault("CGO_ENABLED", "0"),


### PR DESCRIPTION
## What does this PR do?

When debugging the building of this repo, I noticed that we were missing the capability to propagate the verbosity level to the gorelease.

This commit will add the --debug flag to the gorelease only if `-v` is passed from the mage command.


## Why is it important?

This is something that is useful when I was trying to build this repository.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## How to test this PR locally

When you run `mage build:binary` for example it will print the gorelease output in the normal format. 

After this PR running `mage -v build:binary` will increase the verbosity of the gorelease output.
