### PR TITLE
Add infinite retry, fix monitoring

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1086,6 +1086,217 @@ Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-s
 
 
 --------------------------------------------------------------------------------
+Dependency : github.com/elastic/elastic-transport-go/v8
+Version: v8.1.0
+Licence type (autodetected): Apache-2.0
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-transport-go/v8@v8.1.0/LICENSE:
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+--------------------------------------------------------------------------------
 Dependency : github.com/elastic/go-elasticsearch/v8
 Version: v8.6.0
 Licence type (autodetected): Apache-2.0
@@ -20278,217 +20489,6 @@ Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
 Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-autodiscover@v0.2.1/LICENSE:
-
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-
---------------------------------------------------------------------------------
-Dependency : github.com/elastic/elastic-transport-go/v8
-Version: v8.1.0
-Licence type (autodetected): Apache-2.0
---------------------------------------------------------------------------------
-
-Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-transport-go/v8@v8.1.0/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,6 @@ require (
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
-	github.com/elastic/elastic-transport-go/v8 v8.1.0 // indirect
 	github.com/elastic/go-licenser v0.4.1 // indirect
 	github.com/elastic/go-structform v0.0.10 // indirect
 	github.com/elastic/go-sysinfo v1.9.1-0.20230328042007-6dcfe88b8359 // indirect
@@ -108,6 +107,7 @@ require (
 	github.com/Shopify/sarama v1.27.0
 	github.com/docker/go-units v0.5.0
 	github.com/elastic/elastic-agent-system-metrics v0.5.1-0.20230329152224-08d0843327fd
+	github.com/elastic/elastic-transport-go/v8 v8.1.0
 	go.elastic.co/fastjson v1.1.0
 )
 

--- a/monitoring/queuemon.go
+++ b/monitoring/queuemon.go
@@ -104,7 +104,6 @@ func NewFromConfig(httpCfg, logCfg *config.C, target queue.MetricsSource) (*Queu
 
 // a callback passed to monitoring.NewFunc for reporting queue metrics
 func (mon *QueueMonitor) reportQueueMetrics(_ monitoring.Mode, V monitoring.Visitor) {
-	mon.log.Debugf("register called reportQueueMetrics")
 	V.OnRegistryStart()
 	defer V.OnRegistryFinished()
 

--- a/output/elasticsearch/config.go
+++ b/output/elasticsearch/config.go
@@ -6,6 +6,7 @@ package elasticsearch
 
 import (
 	"crypto/tls"
+	"math"
 	"net/http"
 	"runtime"
 	"time"
@@ -33,6 +34,7 @@ type Config struct {
 	Backoff Backoff `config:"backoff"`
 
 	// Default: 3
+	// Setting to -1 will enable infinite retry
 	MaxRetries int `config:"max_retries"`
 
 	// Default: 502, 503, 504.
@@ -121,7 +123,14 @@ func (c Config) esConfig() elasticsearch.Config {
 		// falls back on full verification.
 		tlsConfig.InsecureSkipVerify = true
 	}
+
+	if c.MaxRetries == -1 {
+		// 'infinite' retry
+		c.MaxRetries = math.MaxInt
+	}
+
 	cfg := elasticsearch.Config{
+		EnableMetrics: true,
 		Addresses:     c.Hosts,
 		Username:      c.Username,
 		Password:      c.Password,

--- a/output/elasticsearch/config_test.go
+++ b/output/elasticsearch/config_test.go
@@ -5,9 +5,7 @@
 package elasticsearch
 
 import (
-	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -26,78 +24,6 @@ func TestValidConfig(t *testing.T) {
 func TestInvalidConfig(t *testing.T) {
 	// TODO: Add a real test case here when we do enough config validation
 	// that an invalid outcome is possible.
-}
-
-func TestWatcherPeriodWithNoEvents(t *testing.T) {
-	report := func(state WatchState, s string) {
-		if state == WatchDegraded {
-			t.Logf("got: %s, should not have failed", s)
-			t.Fail()
-		}
-	}
-	watcher := ESHealthWatcher{failureInterval: time.Millisecond * 10, reporter: report, waitInterval: time.Millisecond * 5}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-	go watcher.Watch(ctx)
-	watcher.Success()
-	// should not report failure if it's just been a long period without any events
-	time.Sleep(time.Millisecond * 100)
-}
-
-func TestWatcherWithFail(t *testing.T) {
-	gotFail := false
-	reportFail := func(state WatchState, s string) {
-		t.Logf("got: %s", s)
-		if state == WatchDegraded {
-			gotFail = true
-		}
-
-	}
-	watcher := ESHealthWatcher{failureInterval: time.Millisecond * 10, reporter: reportFail, waitInterval: time.Millisecond * 5}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-
-	go watcher.Watch(ctx)
-
-	watcher.Success()
-	time.Sleep(time.Millisecond * 10)
-	watcher.Fail("simulated failure")
-	// should fail
-	time.Sleep(time.Millisecond * 15)
-	assert.True(t, gotFail, "watcher should report a failure")
-}
-
-func TestWatcherWithFailAndSuccess(t *testing.T) {
-	gotFail := false
-	gotSuccess := false
-	reportMethod := func(state WatchState, s string) {
-		t.Logf("got: %s", s)
-		if state == WatchDegraded {
-			gotFail = true
-		}
-		if state == WatchRecovered {
-			gotSuccess = true
-		}
-	}
-
-	watcher := ESHealthWatcher{failureInterval: time.Millisecond * 10, reporter: reportMethod, waitInterval: time.Millisecond * 2}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-
-	go watcher.Watch(ctx)
-
-	watcher.Success()
-	time.Sleep(time.Millisecond * 10)
-	watcher.Fail("simulated failure")
-	// should fail
-	time.Sleep(time.Millisecond * 15)
-	// report success
-	watcher.Success()
-	time.Sleep(time.Millisecond * 15)
-
-	assert.True(t, gotFail, "watcher should report a failure")
-	assert.True(t, gotSuccess, "watcher should report a healthy status")
-
 }
 
 func readConfig(cfg *config.C) (*Config, error) {

--- a/output/elasticsearch/watcher.go
+++ b/output/elasticsearch/watcher.go
@@ -6,9 +6,11 @@ package elasticsearch
 
 import (
 	"context"
-	"fmt"
-	"sync"
+	"sync/atomic"
 	"time"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-transport-go/v8/elastictransport"
 )
 
 // WatchState represents the state of the output at the time the WatchReporter callback was made
@@ -25,67 +27,136 @@ type WatchReporter func(state WatchState, msg string)
 
 // ESHealthWatcher monitors the ES connection and notifies if a failure persists for more than failureInterval seconds
 type ESHealthWatcher struct {
-	reporter        WatchReporter
-	lastSuccess     time.Time
-	lastFailure     time.Time
-	didFail         bool
-	lastFailMessage string
-	failureInterval time.Duration
-	waitInterval    time.Duration
-
-	mut sync.Mutex
+	reporter          WatchReporter
+	callbackFailCount int32
+	didFail           bool
+	failureInterval   time.Duration
+	waitInterval      time.Duration
+	esClient          ConnectionMetrics
+	log               *logp.Logger
 }
 
-func newHealthWatcher(reporter WatchReporter, failureInterval time.Duration) ESHealthWatcher {
+// ConnectionMetrics is an interface type for ES transport metrics
+type ConnectionMetrics interface {
+	Metrics() (elastictransport.Metrics, error)
+}
+
+//////////// Test helpers
+
+// sets the ticker channel used by the watcher. Used for tests.
+var monitoringTicker = createWatchTicker
+
+// default ticker for the health monitor, can by bypassed for tests
+func createWatchTicker(interval time.Duration) <-chan time.Time {
+	return time.NewTicker(interval).C
+}
+
+// If set, is called every time the watcher loop returns to the start
+// This helps us avoid copious sleep() statements in the tests
+var watcherLoopResetChan chan struct{}
+
+////////////
+
+func newHealthWatcher(log *logp.Logger, reporter WatchReporter, failureInterval time.Duration, client ConnectionMetrics) ESHealthWatcher {
 	return ESHealthWatcher{
+		log:             log,
 		reporter:        reporter,
 		didFail:         false,
 		failureInterval: failureInterval,
-		waitInterval:    time.Second,
+		waitInterval:    time.Second * 5,
+		esClient:        client,
 	}
 }
 
-// Fail updates the time and error message of the last known failure
-func (hw *ESHealthWatcher) Fail(msg string) {
-	hw.mut.Lock()
-	defer hw.mut.Unlock()
-	hw.lastFailure = time.Now()
-	hw.lastFailMessage = msg
+// Fail increments the count of callback failures
+// This helps us determine health status in cases where errors originate outside of the ES transport. JSON errors, etc
+func (hw *ESHealthWatcher) Fail() {
+	atomic.AddInt32(&hw.callbackFailCount, 1)
+
 }
 
-// Success updates the last known successful ES call
-func (hw *ESHealthWatcher) Success() {
-	hw.mut.Lock()
-	defer hw.mut.Unlock()
-	hw.lastSuccess = time.Now()
-}
-
-// Watch starts a blocking loop and will report if there has been a failure for longer than a given period
+// Watch starts a blocking loop and will report if there has been a failure for longer than a given period.
+// This is a blocking call
 func (hw *ESHealthWatcher) Watch(ctx context.Context) {
+
+	// count of failures from the es transport
+	lastFail := 0
+	// count of HTTP response codes in the fail range
+	lastResponseFailRange := 0
+	// count of HTTP response codes in the success range
+	lastResponseSuccessfulRange := 0
+	// is the watcher reported degraded?
+	didFail := false
+	// Count of last failures reported by the callback system
+	var lastCBFail int32
+
+	ticker := monitoringTicker(hw.failureInterval)
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(hw.waitInterval):
-
-		}
-		hw.mut.Lock()
-
-		// if the last success was > failure interval, and a failure was more recent, then report
-		if time.Since(hw.lastSuccess) > hw.failureInterval && hw.lastFailure.After(hw.lastSuccess) && !hw.didFail {
-			hw.didFail = true
-			if hw.reporter != nil {
-				hw.reporter(WatchDegraded, fmt.Sprintf("Degraded: %s", hw.lastFailMessage))
+		case <-ticker:
+			metrics, err := hw.esClient.Metrics()
+			if err != nil {
+				hw.log.Errorf("error fetching metrics from ES cluster: %s", err)
+				continue
 			}
 
-		}
-		if hw.lastSuccess.After(hw.lastFailure) && hw.didFail {
-			hw.didFail = false
-			if hw.reporter != nil {
+			// these return code ranges should probably be configurable?
+			success := returnRangeDelta(200, 299, metrics.Responses)
+			fails := returnRangeDelta(400, 599, metrics.Responses)
+
+			// calculate deltas between last run
+			respFailDelta := fails - lastResponseFailRange
+			respSuccessDelta := success - lastResponseSuccessfulRange
+			transportFailDelta := metrics.Failures - lastFail
+			cbFails := hw.callbackFailCount - lastCBFail
+
+			// the logic here is relatively simple
+			// if there have been no successful HTTP codes since the last reporting period,
+			// but we have gotten a non-zero change in failures, assume we're in a degraded state
+			if respSuccessDelta == 0 {
+				if cbFails > 0 || transportFailDelta > 0 || respFailDelta > 0 {
+					hw.log.Debugf("failure deltas without successful events, marking as degraded; callback fail delta=%d; HTTP transport failures=%d; ES transport failures=%d", cbFails, transportFailDelta, respFailDelta)
+					hw.reporter(WatchDegraded, "Degraded: no responses from ES")
+					didFail = true
+				}
+			} else {
+				hw.log.Debugf("since last monitoring period, watcher got %d successful return codes", respSuccessDelta)
+			}
+
+			// check to see if we're un-failed
+			// Should there be a more complex success condition, other than "we saw some events successfully send"?
+			if didFail && respSuccessDelta > 0 {
+				hw.log.Debugf("got successful events, marking as recovered")
 				hw.reporter(WatchRecovered, "ES is sending events")
+				didFail = false
+			}
+
+			// update trackers
+			lastFail = metrics.Failures
+			lastResponseFailRange = fails
+			lastResponseSuccessfulRange = success
+			lastCBFail = hw.callbackFailCount
+
+			// if we're in a test setting, send a signal telling the test
+			// we're done running through the checks, and the state can be checked
+			if watcherLoopResetChan != nil {
+				hw.log.Debugf("watcher loop done, notifying test")
+				watcherLoopResetChan <- struct{}{}
 			}
 		}
-		hw.mut.Unlock()
-		//time.Sleep(hw.waitInterval)
+
 	}
+}
+
+// return the total sum
+func returnRangeDelta(min, max int, returns map[int]int) int {
+	acc := 0
+	for code, val := range returns {
+		if code >= min && code <= max {
+			acc += val
+		}
+	}
+	return acc
 }

--- a/output/elasticsearch/watcher_test.go
+++ b/output/elasticsearch/watcher_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package elasticsearch
 
 import (

--- a/output/elasticsearch/watcher_test.go
+++ b/output/elasticsearch/watcher_test.go
@@ -1,0 +1,215 @@
+package elasticsearch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-transport-go/v8/elastictransport"
+)
+
+type testESConn struct {
+	data elastictransport.Metrics
+}
+
+func (tc *testESConn) Metrics() (elastictransport.Metrics, error) {
+	return tc.data, nil
+}
+
+func setupTestEnv(reporter WatchReporter) (chan time.Time, *testESConn, ESHealthWatcher, chan struct{}) {
+	_ = logp.DevelopmentSetup()
+	transport := &testESConn{data: elastictransport.Metrics{
+		Responses: map[int]int{},
+	}}
+
+	testTimeTicker := make(chan time.Time)
+
+	monitoringTicker = func(_ time.Duration) <-chan time.Time {
+		return testTimeTicker
+	}
+
+	watcherLoopResetChan = make(chan struct{})
+
+	watcher := newHealthWatcher(logp.L(), reporter, time.Second, transport)
+
+	return testTimeTicker, transport, watcher, watcherLoopResetChan
+}
+
+func TestUnreachableServer(t *testing.T) {
+	gotFail := false
+	reportFail := func(state WatchState, s string) {
+		t.Logf("got: %s", s)
+		if state == WatchDegraded {
+			gotFail = true
+		}
+
+	}
+	testTimeTicker, transport, watcher, watcherLoopResetChan := setupTestEnv(reportFail)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	// add a time so we get one initial loop
+	go watcher.Watch(ctx)
+	testTimeTicker <- time.Now()
+	<-watcherLoopResetChan
+
+	// emulate failures
+	transport.data.Failures = 10
+	testTimeTicker <- time.Now()
+
+	<-watcherLoopResetChan
+	require.True(t, gotFail)
+
+}
+
+func TestFailedReturnCodes(t *testing.T) {
+	gotFail := false
+	reportFail := func(state WatchState, s string) {
+		t.Logf("got: %s", s)
+		if state == WatchDegraded {
+			gotFail = true
+		}
+
+	}
+	testTimeTicker, transport, watcher, resetChan := setupTestEnv(reportFail)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	go watcher.Watch(ctx)
+	testTimeTicker <- time.Now()
+	<-resetChan
+	// emulate failures
+	transport.data.Responses[500] = 10
+	testTimeTicker <- time.Now()
+	<-resetChan
+	require.True(t, gotFail)
+}
+
+func TestMixedReturnCodes(t *testing.T) {
+	gotFail := false
+	reportFail := func(state WatchState, s string) {
+		t.Logf("got: %s", s)
+		if state == WatchDegraded {
+			gotFail = true
+		}
+
+	}
+	testTimeTicker, transport, watcher, resetChan := setupTestEnv(reportFail)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	go watcher.Watch(ctx)
+	testTimeTicker <- time.Now()
+	<-resetChan
+
+	// mix failed events with successful events
+	transport.data.Responses[500] = 10
+	transport.data.Responses[200] = 300
+	testTimeTicker <- time.Now()
+
+	<-resetChan
+	// should not mark as unhealthy
+	require.False(t, gotFail)
+}
+
+func TestSuccessfulThenUnhealthy(t *testing.T) {
+	gotFail := false
+	reportFail := func(state WatchState, s string) {
+		t.Logf("got: %s", s)
+		if state == WatchDegraded {
+			gotFail = true
+		}
+
+	}
+	testTimeTicker, transport, watcher, resetChan := setupTestEnv(reportFail)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	go watcher.Watch(ctx)
+	// generate a mix of fail and successful return codes
+	transport.data.Responses[500] = 10
+	transport.data.Responses[200] = 300
+	testTimeTicker <- time.Now()
+	<-resetChan
+
+	//another period with just failures
+	transport.data.Responses[500] = 20
+	testTimeTicker <- time.Now()
+	<-resetChan
+
+	require.True(t, gotFail)
+}
+
+func TestCallbackFailures(t *testing.T) {
+	gotFail := false
+	reportFail := func(state WatchState, s string) {
+		t.Logf("got: %s", s)
+		if state == WatchDegraded {
+			gotFail = true
+		}
+
+	}
+	testTimeTicker, transport, watcher, resetChan := setupTestEnv(reportFail)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	// start with initial data
+	go watcher.Watch(ctx)
+	transport.data.Responses[500] = 10
+	transport.data.Responses[200] = 300
+	testTimeTicker <- time.Now()
+	<-resetChan
+	// failures specified on callback
+	watcher.Fail()
+	watcher.Fail()
+
+	testTimeTicker <- time.Now()
+	<-resetChan
+
+	require.True(t, gotFail)
+}
+
+func TestFailureWithRecovery(t *testing.T) {
+	gotFail := false
+	reportFail := func(state WatchState, s string) {
+		t.Logf("got: %s", s)
+		if state == WatchDegraded {
+			gotFail = true
+		}
+		if state == WatchRecovered {
+			gotFail = false
+		}
+	}
+	testTimeTicker, transport, watcher, resetChan := setupTestEnv(reportFail)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	// start with a basic mix of failures and success
+	go watcher.Watch(ctx)
+	transport.data.Responses[500] = 10
+	transport.data.Responses[200] = 300
+	testTimeTicker <- time.Now()
+	<-resetChan
+	require.False(t, gotFail)
+
+	// degraded state
+	transport.data.Responses[400] = 10
+	testTimeTicker <- time.Now()
+	<-resetChan
+	require.True(t, gotFail)
+
+	// now recover
+	transport.data.Responses[200] = 350
+	testTimeTicker <- time.Now()
+	<-resetChan
+	require.False(t, gotFail)
+}


### PR DESCRIPTION
## What does this PR do?

Closes https://github.com/elastic/elastic-agent-shipper/issues/262

This PR adds infinite retry functionality, and completely refactors the elasticsearch health monitor. In detail

- If the `max_retries` is set to `-1`, this enables "infinite" retry, which just sets the ES MaxRetries to `MaxInt`.
- Because many common error conditions will now retry instead of trickling down to `OnFailure`, the monitor instead watches the raw HTTP return codes coming from the elasticsearch transport, and checks the deltas.
- The monitor will mark the ES output as unhealthy if zero successful HTTP codes are reported in a given period, and > 0 error conditions are reported across the reporting period

## Why is it important?

We want infinite retry.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md` or `CHANGELOG-developer.md`.


## How to test this PR locally

- Pull down and build
- Run either standalone or with agent
- Set `max_retries` to `-1`:
```
outputs:
  default:
    log_level: debug
    type: elasticsearch
    hosts: [https://127.0.0.1:9200]
    username: "elastic"
    password: "changeme"
    bulk_max_size: 4096
    max_retries: -1
    ssl:
      verification_mode: none
    shipper:
      log_level: debug
      enabled: true
      bulk_max_size: 2048
```

- Ensure that events send properly
- Break Elasticsearch
- Run again, ensure that the shipper reports a degraded state
